### PR TITLE
fix: correct Helpers class namespace to match PSR-4 autoload config

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -126,7 +126,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             "customer" => [
                     "address_1" => $this->cleanForFraud($billing->getStreetLine(1) . ' ' . $billing->getStreetLine(2), self::RE_ANS, 30),
                     "city" => $this->cleanForFraud($billing->getCity(), self::RE_ANS, 20),
-                    "country" => \FatZebra\Helpers::iso3166_alpha3($billing->getCountryId()),
+                    "country" => \FatZebra\Gateway\Model\Helpers::iso3166_alpha3($billing->getCountryId()),
                     "created_at" => $customerCreatedAt,
                     "date_of_birth" => $customerDob,
                     "email" => $order->getCustomerEmail(),
@@ -143,7 +143,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                 [
                     "address_1" => $this->cleanForFraud($billing->getStreetLine(1) . ' ' . $billing->getStreetLine(2), self::RE_ANS, 30),
                     "city" => $this->cleanForFraud($billing->getCity(), self::RE_ANS, 20),
-                    "country" => \FatZebra\Helpers::iso3166_alpha3($billing->getCountryId()),
+                    "country" => \FatZebra\Gateway\Model\Helpers::iso3166_alpha3($billing->getCountryId()),
                     "email" => $billing->getEmail(),
                     "first_name" => $this->cleanForFraud($billing->getFirstname(), self::RE_ANS, 30),
                     "last_name" => $this->cleanForFraud($billing->getLastname(), self::RE_ANS, 30),
@@ -159,7 +159,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             $fraudData["shipping_address"] = [
                 "address_1" => $this->cleanForFraud($shipping->getStreetLine(1) . ' ' . $shipping->getStreetLine(2), self::RE_ANS, 30),
                 "city" => $this->cleanForFraud($shipping->getCity(), self::RE_ANS, 20),
-                "country" => \FatZebra\Helpers::iso3166_alpha3($billing->getCountryId()),
+                "country" => \FatZebra\Gateway\Model\Helpers::iso3166_alpha3($billing->getCountryId()),
                 "email" => $shipping->getEmail(),
                 "first_name" => $this->cleanForFraud($shipping->getFirstname(), self::RE_ANS, 30),
                 "last_name" => $this->cleanForFraud($shipping->getLastname(), self::RE_ANS, 30),
@@ -174,7 +174,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
     public function cleanForFraud($data, $pattern, $maxlen, $trimDirection = 'right')
     {
-        $data = preg_replace($pattern, '', \FatZebra\Helpers::toASCII($data));
+        $data = preg_replace($pattern, '', \FatZebra\Gateway\Model\Helpers::toASCII($data));
         $data = preg_replace('/[\r\n]/', ' ', $data);
         if (strlen($data) > $maxlen) {
             if ($trimDirection == 'right') {

--- a/Model/Helpers.php
+++ b/Model/Helpers.php
@@ -12,7 +12,7 @@
 *
 * @package FatZebra
 */
-namespace FatZebra;
+namespace FatZebra\Gateway\Model;
 
 class Helpers
 {


### PR DESCRIPTION
## Summary

- `Model/Helpers.php` declared `namespace FatZebra;` but `composer.json` only has PSR-4 mapping for `FatZebra\Gateway\` → root directory
- This made `\FatZebra\Helpers` unresolvable by the autoloader, causing fatal `Class "FatZebra\Helpers" not found` errors at runtime
- Fix: change namespace to `FatZebra\Gateway\Model` (matches PSR-4 mapping + file location) and update all 4 call sites in `Helper/Data.php`

Closes #2