### PR TITLE
fix: resolve 6 critical runtime-fatal bugs

### DIFF
--- a/Gateway/RefundCommand.php
+++ b/Gateway/RefundCommand.php
@@ -24,14 +24,14 @@ class RefundCommand extends AbstractCommand
         $gateway = $this->getGateway($payment->getOrder()->getStoreId());
         // At this point, we don't have a CreditMemo increment ID, so append a timestamp to ensure uniqueness in the event
         // of multiple refunds against a single invoice.
-        $reference = $this->fatzebaHelper->getOrderReference($payment->getOrder()) . '-R-' . (new \DateTime())->format('ymdhi');
+        $reference = $this->fatzebraHelper->getOrderReference($payment->getOrder()) . '-R-' . (new \DateTime())->format('ymdhi');
         $response = $gateway->refund($payment->getLastTransId(), $commandSubject['amount'], $reference);
-        if (is_array($response) && array_key_exists('successful', $response)) {
-            if ($response['successful'] === true) {
+        if (is_array($response) && isset($response['response'])) {
+            if ($response['response']['successful'] === true) {
                 $payment->setLastTransId($response['response']['transaction_id']);
             } else {
-                $errors = array_key_exists('errors', $response) ? implode('. ', $response['errors']) : 'Unknown gateway error';
-                $this->logger->critical(__('Refund failed for Order #%1. %2', $payment->getOrder()->getIncrementId()), $errors);
+                $errors = isset($response['errors']) ? implode('. ', $response['errors']) : 'Unknown gateway error';
+                $this->logger->critical(__('Refund failed for Order #%1. %2', $payment->getOrder()->getIncrementId(), $errors));
                 throw new \Exception(__('Refund failed: %1', $errors));
             }
         }

--- a/Model/Gateway.php
+++ b/Model/Gateway.php
@@ -26,7 +26,7 @@
     */
 namespace FatZebra\Gateway\Model;
 
-use Zend\Http\Client\Adapter\Exception\TimeoutException;
+use Laminas\Http\Client\Adapter\Exception\TimeoutException;
 
 /**
 * The Fat Zebra Gateway class for interfacing with Fat Zebra

--- a/Observer/AssignDataObserver.php
+++ b/Observer/AssignDataObserver.php
@@ -24,7 +24,7 @@ class AssignDataObserver extends \Magento\Payment\Observer\AbstractDataAssignObs
             $paymentInfo->setAdditionalInformation('fatzebra_token', $additionalData['cc_token']);
         }
         if (isset($additionalData['pmnts_id']) && !empty($additionalData['pmnts_id'])) {
-            $paymentInfo->setAdditionalInformation('fatzebra_device_id', $additionalData['pmnts_id']);
+            $paymentInfo->setAdditionalInformation('pmmts_device_id', $additionalData['pmnts_id']);
         }
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -94,7 +94,7 @@
 
     <virtualType name="FatZebraGatewayLogger" type="Magento\Framework\Logger\Monolog">
         <arguments>
-            <argument name="name" xsi:type="object">fatzebra_gateway</argument>
+            <argument name="name" xsi:type="string">fatzebra_gateway</argument>
             <argument name="handlers" xsi:type="array">
                 <item name="default" xsi:type="object">FatZebraGatewayLoggerHandler</item>
             </argument>


### PR DESCRIPTION
## Summary

Six bugs that cause fatal errors or silent data corruption at runtime:

- **RefundCommand** (`Gateway/RefundCommand.php`):
  - Typo `$this->fatzebaHelper` → `$this->fatzebraHelper` — every refund threw `Error: Undefined property`
  - Response check used `$response['successful']` — key is actually `$response['response']['successful']`, so success was never detected and every refund was treated as failed
  - `$errors` was passed as second arg to `logger->critical()` (the context array slot) instead of inside `__()`, so `%2` was never substituted in the log message

- **AssignDataObserver** (`Observer/AssignDataObserver.php`):
  - Device ID stored as `fatzebra_device_id` but read back in `Helper/Data.php:140` as `pmmts_device_id` — device ID was always `null` in fraud payloads

- **Gateway** (`Model/Gateway.php`):
  - `use Zend\Http\Client\Adapter\Exception\TimeoutException` — `Zend\Http` was removed in Magento 2.4; replaced with `Laminas\Http`

- **DI config** (`etc/di.xml`):
  - Logger `name` argument had `xsi:type="object"` — DI compiler tried to instantiate a class named `fatzebra_gateway`, which does not exist, causing compilation failure

## Test plan

- [ ] Trigger a refund on an order and verify it succeeds without fatal error
- [ ] Verify refund failure path logs the correct error message with order ID and error text
- [ ] Verify fraud payload includes `device_id` when `pmnts_id` is submitted at checkout
- [ ] Run `bin/magento setup:di:compile` — should complete without errors on Magento 2.4+