### PR TITLE
lowercase fatzebraGateway, to match casing in fatzebra-method.js

### DIFF
--- a/Model/Config/FatZebraConfigProvider.php
+++ b/Model/Config/FatZebraConfigProvider.php
@@ -48,7 +48,7 @@ class FatZebraConfigProvider implements ConfigProviderInterface
     {
         $config = [
             'payment' => [
-                'FatZebraGateway' => [
+                'fatzebraGateway' => [
                     'iframeSrc' => $this->getIframeSrc(),
                     'fraudFingerprintSrc' => $this->getFraudFingerprintSource(),
                     'isSandbox' => $this->getIsSandbox(),


### PR DESCRIPTION
The code in fatzebra-method.js cannot find the right settings with the case mismatching.

This now renders the credit card form, which is not displaying here due to me rendering it locally with `http`, but the URL using `https`. The URL is:

https://paynow.pmnts-sandbox.io/v2/TEST/ehvz5/AUD/1.0/958353f1a5cff903706ebf2b5febea7f?show_extras=false&show_email=false&iframe=true&paypal=false&tokenize_only=true&masterpass=false&visacheckout=false&hide_button=true&postmessage=true&return_target=_self&ajax=true&css=https://pmnts-resources.s3.amazonaws.com/magento2/magento2-iframe.css&css_signature=0f87b7f423ac8773a40f42d3bfb6e890

Which is a correct URL.